### PR TITLE
Futures / Promises, Event types

### DIFF
--- a/proposals/common/nfc.html
+++ b/proposals/common/nfc.html
@@ -166,9 +166,10 @@ The NFC API supports the following features:
 
 <!---------------------- Extended interface Navigator ------------------------>
 <section>
-  <h2><a>NFC</a> object</h2>
-  <p>The <a>NFCManager</a> interface is exposed on the <code>Navigator
-  </code> object.
+  <h2>Extensions to <code>Navigator</code> object</h2>
+  <p>The <a>NFCManager</a> interface is exposed on [[!HTML]]'s
+  <a href="http://www.whatwg.org/specs/web-apps/current-work/#dom-navigator">
+  <code>Navigator</code></a> object.
   </p>
   <dl title="partial interface Navigator" class="idl">
     <dt>readonly attribute NFCManager nfc</dt>


### PR DESCRIPTION
A few editorial changes, catching up with the SysApps Telephony API. Most notably:
- Replaced Futures with Promises, update Terminology section linking to the http://dom.spec.whatwg.org/#promise definition
- Defined specific interfaces for events with associated data.
